### PR TITLE
update opentelemetry dependencies to the latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,21 +14,21 @@ homepage = "https://github.com/davidB/axum-tracing-opentelemetry"
 axum = "0.5"
 # axum-core = "0.2"
 http = "0.2"
-opentelemetry = { version = "0.17", features = ["rt-tokio", "serialize"] }
-opentelemetry-jaeger = { version = "0.16", features = [
+opentelemetry = { version = "0.18", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.17", features = [
   "rt-tokio",
 ], optional = true }
-opentelemetry-semantic-conventions = { version = "0.9", optional = true }
-opentelemetry-otlp = { version = "0.10", optional = true, features = [
+opentelemetry-semantic-conventions = { version = "0.10", optional = true }
+opentelemetry-otlp = { version = "0.11", optional = true, features = [
   "http-proto",
 ] }
 tower-http = { version = "0.3", features = ["trace"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.17"
+tracing-opentelemetry = "0.18"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"
-opentelemetry-otlp = { version = "0.10", features = [
+opentelemetry-otlp = { version = "0.11", features = [
   "http-proto",
   "reqwest-client",
   "reqwest-rustls",

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -155,7 +155,7 @@ impl<B> MakeSpan<B> for OtelMakeSpan {
             http.status_code = Empty,
             http.target = %http_target,
             http.user_agent = %user_agent,
-            otel.kind = %opentelemetry::trace::SpanKind::Server,
+            otel.kind = %"server",
             otel.status_code = Empty,
             trace_id = %trace_id,
         );


### PR DESCRIPTION
I also had to use a `str` instead of `SpanKind` because its Display impl was removed. I checked on tracing-opentelemetry and they did the same.

I suppose we need to go to `0.5` to release it?