### PR TITLE
Compile with axum 0.6.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/davidB/axum-tracing-opentelemetry"
 homepage = "https://github.com/davidB/axum-tracing-opentelemetry"
 
 [dependencies]
-axum = "0.5"
+axum = "0.6.0-rc.2"
 # axum-core = "0.2"
 http = "0.2"
 opentelemetry = { version = "0.18", features = ["rt-tokio"] }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -440,7 +440,7 @@ mod tests {
     }
 
     async fn spans_for_requests<const N: usize>(
-        mut router: Router<Body>,
+        mut router: Router,
         reqs: [Request<Body>; N],
     ) -> [(Value, Value); N] {
         use axum::body::HttpBody as _;


### PR DESCRIPTION
Currently extracting the route path silently fails with axum 0.6 RC. With this change, the path is available.

I'm not sure of the timeframe for the 0.6 release; I would like to hope it would be available soon, but https://github.com/tokio-rs/axum/issues/1416 makes me think it may take a bit more time.