### PR TITLE
Fix compile error with only `tracer` feature configured.

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(any(feature = "jaeger", feature = "otlp"))]
+#[cfg(any(feature = "jaeger", feature = "otlp", feature = "tracer"))]
 use opentelemetry::sdk::Resource;
-#[cfg(any(feature = "jaeger", feature = "otlp"))]
+#[cfg(any(feature = "jaeger", feature = "otlp", feature = "tracer"))]
 use opentelemetry::{sdk::trace as sdktrace, trace::TraceError};
 #[cfg(feature = "tracer")]
 use opentelemetry_semantic_conventions as semcov;


### PR DESCRIPTION
If only the `tracer` feature is enabled, then the library fails to compile, with missing symbols `sdktrace`, `TraceError` and `Resource`.

This change makes those imports available for this configuration.