### PR TITLE
fix: fallback to req uri path for nested route 

### DIFF
--- a/src/middleware/trace_extractor.rs
+++ b/src/middleware/trace_extractor.rs
@@ -134,7 +134,7 @@ impl<B> MakeSpan<B> for OtelMakeSpan {
         let http_route = req
             .extensions()
             .get::<MatchedPath>()
-            .map_or("", |mp| mp.as_str())
+            .map_or_else(|| req.uri().path(), |mp| mp.as_str())
             .to_owned();
 
         let uri = if let Some(uri) = req.extensions().get::<OriginalUri>() {


### PR DESCRIPTION
fallback to req uri path for nested route (we can not get matched router in nested router handler)

otherwise our span name will be strange.

this is a known issue for Axum: https://github.com/tokio-rs/axum/issues/1441

this PR is a workaround.
